### PR TITLE
DL-4937 - Amended scalatestplus-play version for Play 2.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val compileDeps = Seq(
 def testDeps(scope: String) = Seq(
   "org.scalatest" %% "scalatest" % "3.0.9" % scope,
   "org.mockito" % "mockito-core" % "3.6.28" % scope,
-  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3" % scope,
+  "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % scope,
   "com.github.tomakehurst" % "wiremock" % "2.27.2" % scope,
   "uk.gov.hmrc" %% "reactivemongo-test" % "4.22.0-play-27" % scope
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers ++= Seq(
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.13.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 


### PR DESCRIPTION
# DL-4937 - Amended scalatestplus-play version for Play 2.7

An incorrect version for scalatestplus-play is being used for OPRA after the Play 2.7 upgrade, causing Jenkins to fail with `AbstractMethodError` exceptions.

The table of `play` -> `scalatestplus-play` versions is: https://github.com/playframework/scalatestplus-play

Local testing didn't catch this as the correct version was cached on my machine but wasn't a project dependency.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
