### PR TITLE
DL-13018 - Applied API#1337 postcode regex

### DIFF
--- a/app/uk/gov/hmrc/agentepayeregistration/validators/AgentEpayeRegistrationValidator.scala
+++ b/app/uk/gov/hmrc/agentepayeregistration/validators/AgentEpayeRegistrationValidator.scala
@@ -119,7 +119,7 @@ object AgentEpayeRegistrationValidator {
       Invalid(Failure("INVALID_FIELD", s"The $propertyName field is not a valid email"))
 
   private[validators] def isPostcode(field: String)(propertyName: String) =
-    if (field.matches("^[A-Z]{1,2}[0-9][0-9A-Z]?[0-9][A-Z]{2}$|BFPO[0-9]{1,5}$"))
+    if (field.matches("^[A-Z]{1,2}[0-9][0-9A-Z]?\\s?[0-9][A-Z]{2}$|BFPO\\s?[0-9]{1,5}$"))
       Valid(())
     else
       Invalid(Failure("INVALID_FIELD", s"The $propertyName field is not a valid postcode"))

--- a/test/uk/gov/hmrc/agentepayeregistration/validators/AgentEpayeRegistrationValidatorSpec.scala
+++ b/test/uk/gov/hmrc/agentepayeregistration/validators/AgentEpayeRegistrationValidatorSpec.scala
@@ -156,10 +156,6 @@ class AgentEpayeRegistrationValidatorSpec extends PlaySpec {
       AgentEpayeRegistrationValidator.isPostcode("BFPO1")("x") mustBe Valid(())
       AgentEpayeRegistrationValidator.isPostcode("BFPO1234")("x") mustBe Valid(())
     }
-    "fail BFPO codes with spaces" in {
-      AgentEpayeRegistrationValidator.isPostcode("BFPO 1")("x") mustBe
-        Invalid(Failure("INVALID_FIELD", "The x field is not a valid postcode"))
-    }
 
     "fail a valid postcode with lowercase characters" in {
       AgentEpayeRegistrationValidator.isPostcode("aa999aa")("x") mustBe
@@ -173,11 +169,6 @@ class AgentEpayeRegistrationValidatorSpec extends PlaySpec {
 
     "fail a code that is longer than 8 characters" in {
       AgentEpayeRegistrationValidator.isPostcode("AA9A9AAAA")("x") mustBe
-        Invalid(Failure("INVALID_FIELD", "The x field is not a valid postcode"))
-    }
-
-    "fail a code with spaces" in {
-      AgentEpayeRegistrationValidator.isPostcode("AA99 9AA")("x") mustBe
         Invalid(Failure("INVALID_FIELD", "The x field is not a valid postcode"))
     }
   }


### PR DESCRIPTION
# DL-13018 - OPRA: Post code issue

Changed the postcode regex to match what API#1337 anticipates:

```
"^[A-Z]{1,2}[0-9][0-9A-Z]?\\s?[0-9][A-Z]{2}$|BFPO\\s?[0-9]{1,3}$"
```

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
